### PR TITLE
Added Ts randomization routines

### DIFF
--- a/docs/process.randomize.md
+++ b/docs/process.randomize.md
@@ -1,0 +1,11 @@
+::: pynapple.process.randomize
+	handler: python
+	selection:
+		docstring_style: numpy
+	rendering:
+		show_root_heading: false
+		show_source: true
+		show_category_heading: false
+		members_order: source
+		
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ nav:
       - Tuning curves: process.tuning_curves.md
       - Decoding: process.decoding.md
       - Peri-Stimulus: process.perievent.md
+      - Randomzation: process.randomize.md
   # - Plugins:
   #   - pynalog: pynalog.md
   #   - pynapplesonfire: pynapplesonfire.md

--- a/pynapple/process/__init__.py
+++ b/pynapple/process/__init__.py
@@ -2,3 +2,4 @@ from .correlograms import *
 from .decoding import *
 from .perievent import *
 from .tuning_curves import *
+from .randomize import *

--- a/pynapple/process/randomize.py
+++ b/pynapple/process/randomize.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+# @Author: dspalla
+# @Date:   2022-01-30 22:59:00
+# @Last Modified by:   dspalla
+# @Last Modified time: 2022-11-17 17:16:16
+
+import numpy as np
+
+from .. import core as nap
+
+
+def shift_timestamps(ts,min_shift=0.0,max_shift=None):
+    """
+    Shifts all the time stamps of a random amount between min_shift and max_shift, wrapping the
+    end of the time support to the beginning.
+
+
+    Parameters
+    ----------
+    timestamps : Ts or TsGroup
+        The timestamps to shift. If TsGroup, shifts all Ts in the group independently.
+    min_shift : float, optional
+        minimum shift (default: 0 )
+    max_shift : float, optional
+        maximum shift, (default: length of time support)
+
+    Returns
+    -------
+    Ts or TsGroup
+        The randomly shifted timestamps
+    """
+    strategies = {nap.core.time_series.Ts:_shift_ts,
+                  nap.core.ts_group.TsGroup:_shift_tsgroup,
+                  }
+    # checks input type              
+    if type(ts) not in strategies.keys():
+        raise TypeError('Invalid input type, should be Ts or TsGroup')
+
+    # checks max shift < len of time support  
+    if max_shift > abs(ts.end_time - ts.start_time):
+        raise ValueError('Invalid max_shift, max_shift > length of time support')
+
+    strategy = strategies[type(ts)]
+    return strategy(ts,min_shift,max_shift)
+
+
+def _shift_ts(ts,min_shift=0,max_shift=None):
+    """
+    Shifts all the time stamps of a random amount between min_shift and max_shift, wrapping the
+    end of the time support to the beginning.
+
+
+    Parameters
+    ----------
+    timestamps : Ts 
+        The timestamps to shift.
+    min_shift : float, optional
+        minimum shift (default: 0 )
+    max_shift : float, optional
+        maximum shift, (default: length of time support)
+
+    Returns
+    -------
+    Ts 
+        The randomly shifted timestamps
+    """
+
+    if max_shift == None:
+        max_shift = ts.end_time() - ts.start_time()
+    shift = np.random.uniform(min_shift,max_shift)
+    shifted_timestamps = (ts.times() + shift) % ts.end_time() + ts.start_time()
+    shifted_ts = nap.Ts(t=np.sort(shifted_timestamps))
+    return shifted_ts
+
+
+def _shift_tsgroup(tsgroup,min_shift=0,max_shift=None):
+    """
+    Shifts each Ts in the Ts group independently.
+
+
+    Parameters
+    ----------
+    timestamps : TsGroup
+        The collection of Ts to shift.
+    min_shift : float, optional
+        minimum shift (default: 0 )
+    max_shift : float, optional
+        maximum shift, (default: length of time support)
+
+    Returns
+    -------
+    TsGroup
+        The TSGroup with randomly shifted timestamps
+    """
+
+    start_time = tsgroup.time_support.start[0]
+    end_time = tsgroup.time_support.end[0]
+
+    if max_shift == None:
+        max_shift = end_time - start_time
+
+    shifted_tsgroup = {}
+    for k in tsgroup.keys():
+        shift = np.random.uniform(min_shift,max_shift)
+        shifted_timestamps = (tsgroup[k].times() + shift) % end_time + start_time
+        shifted_tsgroup[k] = nap.Ts(t=np.sort(shifted_timestamps))
+    return nap.TsGroup(shifted_tsgroup)

--- a/pynapple/process/randomize.py
+++ b/pynapple/process/randomize.py
@@ -1,12 +1,8 @@
-# -*- coding: utf-8 -*-
-# @Author: dspalla
-# @Date:   2022-01-30 22:59:00
-# @Last Modified by:   dspalla
-# @Last Modified time: 2022-11-17 17:16:16
-
 import numpy as np
 
 from .. import core as nap
+
+# Random shift
 
 
 def shift_timestamps(ts,min_shift=0.0,max_shift=None):
@@ -29,16 +25,12 @@ def shift_timestamps(ts,min_shift=0.0,max_shift=None):
     Ts or TsGroup
         The randomly shifted timestamps
     """
-    strategies = {nap.core.time_series.Ts:_shift_ts,
-                  nap.core.ts_group.TsGroup:_shift_tsgroup,
+    strategies = {nap.time_series.Ts : _shift_ts,
+                  nap.ts_group.TsGroup : _shift_tsgroup,
                   }
     # checks input type              
     if type(ts) not in strategies.keys():
         raise TypeError('Invalid input type, should be Ts or TsGroup')
-
-    # checks max shift < len of time support  
-    if max_shift > abs(ts.end_time - ts.start_time):
-        raise ValueError('Invalid max_shift, max_shift > length of time support')
 
     strategy = strategies[type(ts)]
     return strategy(ts,min_shift,max_shift)
@@ -69,7 +61,7 @@ def _shift_ts(ts,min_shift=0,max_shift=None):
         max_shift = ts.end_time() - ts.start_time()
     shift = np.random.uniform(min_shift,max_shift)
     shifted_timestamps = (ts.times() + shift) % ts.end_time() + ts.start_time()
-    shifted_ts = nap.Ts(t=np.sort(shifted_timestamps))
+    shifted_ts = nap.Ts(t=np.sort(shifted_timestamps),time_support=ts.time_support)
     return shifted_ts
 
 
@@ -104,4 +96,185 @@ def _shift_tsgroup(tsgroup,min_shift=0,max_shift=None):
         shift = np.random.uniform(min_shift,max_shift)
         shifted_timestamps = (tsgroup[k].times() + shift) % end_time + start_time
         shifted_tsgroup[k] = nap.Ts(t=np.sort(shifted_timestamps))
-    return nap.TsGroup(shifted_tsgroup)
+    return nap.TsGroup(shifted_tsgroup,time_support=tsgroup.time_support)
+
+# Random jitter
+
+
+def jitter_timestamps(ts,min_jitter=0.0,max_jitter=None,keep_tsupport=False):
+    """
+    Jitters each time stamp independently of a random amount between min_jitter and max_jitter.
+
+
+    Parameters
+    ----------
+    timestamps : Ts or TsGroup
+        The timestamps to jitter. If TsGroup, jitter is applied to each element of the group.
+    min_jitter : float, optional
+        minimum jitter (default: 0 )
+    max_jitter : float
+        maximum jitter
+    keep_tsupport: bool, optional
+        If True, keep time support of the input. The number of timestamps will not be conserved.
+        If False, the time support is inferred from the jittered timestamps. The number of tmestamps
+        is conserved. (default: False)
+
+    Returns
+    -------
+    Ts or TsGroup
+        The jittered timestamps
+    """
+    strategies = {nap.time_series.Ts : _jitter_ts,
+                  nap.ts_group.TsGroup : _jitter_tsgroup,
+                  }
+    # checks input type              
+    if type(ts) not in strategies.keys():
+        raise TypeError('Invalid input type, should be Ts or TsGroup')
+
+    if max_jitter == None:
+        raise TypeError('missing required argument: max_jitter ')
+
+    strategy = strategies[type(ts)]
+    return strategy(ts,min_jitter,max_jitter,keep_tsupport)
+
+
+def _jitter_ts(ts,min_jitter=0,max_jitter=None,keep_tsupport=False):
+    """
+    Parameters
+    ----------
+    timestamps : Ts 
+        The timestamps to jitter.
+    min_jitter : float, optional
+        minimum jitter (default: 0 )
+    max_jitter : float
+        maximum jitter
+    keep_tsupport: bool, optional
+        If True, keep time support of the input. The number of timestamps will not be conserved.
+        If False, the time support is inferred from the jittered timestamps. The number of tmestamps
+        is conserved. (default: False)
+
+    Returns
+    -------
+    Ts 
+        The jittered timestamps
+    """
+    jittered_timestamps = ts.times() + np.random.uniform(min_jitter,max_jitter,len(ts))
+    if keep_tsupport:
+        jittered_ts = nap.Ts(t=np.sort(jittered_timestamps),time_support=ts.time_support)
+    else:
+        jittered_ts = nap.Ts(t=np.sort(jittered_timestamps))
+
+    return jittered_ts
+
+
+def _jitter_tsgroup(tsgroup,min_jitter=0,max_jitter=None,keep_tsupport=False):
+    """
+    Jitters each time stamp, in each element of the group,
+    independently of a random amount between min_jitter and max_jitter.
+
+
+    Parameters
+    ----------
+    timestamps : TsGroup
+        The timestamps to jitter, the jitter is applied to each element of the group.
+    min_jitter : float, optional
+        minimum jitter (default: 0 )
+    max_jitter : float
+        maximum jitter
+    keep_tsupport: bool, optional
+        If True, keep time support of the input. The number of timestamps will not be conserved.
+        If False, the time support is inferred from the jittered timestamps. The number of tmestamps
+        is conserved. (default: False)
+
+    Returns
+    -------
+    TsGroup
+        The jittered timestamps
+    """
+
+    jittered_tsgroup = {}
+    for k in tsgroup.keys():
+        jittered_timestamps = tsgroup[k].times() + np.random.uniform(min_jitter,max_jitter,len(tsgroup[k]))
+        jittered_tsgroup[k] = nap.Ts(t=np.sort(jittered_timestamps))
+
+    if keep_tsupport:
+        jittered_tsgroup = nap.TsGroup(jittered_tsgroup,time_support=tsgroup.time_support)
+    else:
+        jittered_tsgroup = nap.TsGroup(jittered_tsgroup)
+
+    return jittered_tsgroup
+
+
+# Random resample
+def resample_timestamps(ts):
+    """
+    Resamples the timestamps in the time support, with uniform distribution.
+
+
+    Parameters
+    ----------
+    timestamps : Ts or TsGroup
+        The timestamps to resample. If TsGroup, each Ts object in the group is independently
+        resampled, in the time support of the whole group.
+
+
+    Returns
+    -------
+    Ts or TsGroup
+        The resampled timestamps
+    """
+    strategies = {nap.time_series.Ts : _resample_ts,
+                  nap.ts_group.TsGroup : _resample_tsgroup,
+                  }
+    # checks input type              
+    if type(ts) not in strategies.keys():
+        raise TypeError('Invalid input type, should be Ts or TsGroup')
+
+    strategy = strategies[type(ts)]
+    return strategy(ts)
+
+
+def _resample_ts(ts):
+    """
+    Resamples the timestamps in the time support, with uniform distribution.
+
+    Parameters
+    ----------
+    timestamps : Ts 
+        The timestamps to resample.
+    Returns
+    -------
+    Ts 
+        The resampled timestamps
+    """
+    resampled_timestamps = np.random.uniform(ts.start_time(),ts.end_time(),len(ts))
+    resampled_ts = nap.Ts(t=np.sort(resampled_timestamps),time_support=ts.time_support)
+
+    return resampled_ts
+
+
+def _resample_tsgroup(tsgroup):
+    """
+    Resamples the each timestamp series in the group, with uniform distribution and on the time
+    support of the whole group.
+
+    Parameters
+    ----------
+    timestamps : TsGroup
+        The TsGroup to resample, each Ts object in the group is independently
+        resampled, in the time support of the whole group.
+
+    Returns
+    -------
+    TsGroup
+        The resampled TsGroup
+    """
+    start_time = tsgroup.time_support.start[0]
+    end_time = tsgroup.time_support.end[0]
+
+    resampled_tsgroup = {}
+    for k in tsgroup.keys():
+        resampled_timestamps = np.random.uniform(start_time,end_time,len(tsgroup[k]))
+        resampled_tsgroup[k] = nap.Ts(t=np.sort(resampled_timestamps))
+
+    return nap.TsGroup(resampled_tsgroup,time_support=tsgroup.time_support)

--- a/pynapple/process/randomize.py
+++ b/pynapple/process/randomize.py
@@ -103,15 +103,13 @@ def _shift_tsgroup(tsgroup,min_shift=0,max_shift=None):
 
 def jitter_timestamps(ts,max_jitter=None,keep_tsupport=False):
     """
-    Jitters each time stamp independently of a random amount between min_jitter and max_jitter.
+    Jitters each time stamp independently of random amounts uniformly drawn between -max_jitter and max_jitter.
 
 
     Parameters
     ----------
     timestamps : Ts or TsGroup
         The timestamps to jitter. If TsGroup, jitter is applied to each element of the group.
-    min_jitter : float, optional
-        minimum jitter (default: 0 )
     max_jitter : float
         maximum jitter
     keep_tsupport: bool, optional
@@ -144,8 +142,6 @@ def _jitter_ts(ts,max_jitter=None,keep_tsupport=False):
     ----------
     timestamps : Ts 
         The timestamps to jitter.
-    min_jitter : float, optional
-        minimum jitter (default: 0 )
     max_jitter : float
         maximum jitter
     keep_tsupport: bool, optional
@@ -169,16 +165,13 @@ def _jitter_ts(ts,max_jitter=None,keep_tsupport=False):
 
 def _jitter_tsgroup(tsgroup,max_jitter=None,keep_tsupport=False):
     """
-    Jitters each time stamp, in each element of the group,
-    independently of a random amount between min_jitter and max_jitter.
-
+    Jitters each time stamp independently, for each element in the TsGroup
+    of random amounts uniformly drawn between -max_jitter and max_jitter.
 
     Parameters
     ----------
     timestamps : TsGroup
         The timestamps to jitter, the jitter is applied to each element of the group.
-    min_jitter : float, optional
-        minimum jitter (default: 0 )
     max_jitter : float
         maximum jitter
     keep_tsupport: bool, optional

--- a/pynapple/process/randomize.py
+++ b/pynapple/process/randomize.py
@@ -101,7 +101,7 @@ def _shift_tsgroup(tsgroup,min_shift=0,max_shift=None):
 # Random jitter
 
 
-def jitter_timestamps(ts,min_jitter=0.0,max_jitter=None,keep_tsupport=False):
+def jitter_timestamps(ts,max_jitter=None,keep_tsupport=False):
     """
     Jitters each time stamp independently of a random amount between min_jitter and max_jitter.
 
@@ -135,10 +135,10 @@ def jitter_timestamps(ts,min_jitter=0.0,max_jitter=None,keep_tsupport=False):
         raise TypeError('missing required argument: max_jitter ')
 
     strategy = strategies[type(ts)]
-    return strategy(ts,min_jitter,max_jitter,keep_tsupport)
+    return strategy(ts,max_jitter,keep_tsupport)
 
 
-def _jitter_ts(ts,min_jitter=0,max_jitter=None,keep_tsupport=False):
+def _jitter_ts(ts,max_jitter=None,keep_tsupport=False):
     """
     Parameters
     ----------
@@ -158,7 +158,7 @@ def _jitter_ts(ts,min_jitter=0,max_jitter=None,keep_tsupport=False):
     Ts 
         The jittered timestamps
     """
-    jittered_timestamps = ts.times() + np.random.uniform(min_jitter,max_jitter,len(ts))
+    jittered_timestamps = ts.times() + np.random.uniform(-max_jitter,max_jitter,len(ts))
     if keep_tsupport:
         jittered_ts = nap.Ts(t=np.sort(jittered_timestamps),time_support=ts.time_support)
     else:
@@ -167,7 +167,7 @@ def _jitter_ts(ts,min_jitter=0,max_jitter=None,keep_tsupport=False):
     return jittered_ts
 
 
-def _jitter_tsgroup(tsgroup,min_jitter=0,max_jitter=None,keep_tsupport=False):
+def _jitter_tsgroup(tsgroup,max_jitter=None,keep_tsupport=False):
     """
     Jitters each time stamp, in each element of the group,
     independently of a random amount between min_jitter and max_jitter.
@@ -194,7 +194,7 @@ def _jitter_tsgroup(tsgroup,min_jitter=0,max_jitter=None,keep_tsupport=False):
 
     jittered_tsgroup = {}
     for k in tsgroup.keys():
-        jittered_timestamps = tsgroup[k].times() + np.random.uniform(min_jitter,max_jitter,len(tsgroup[k]))
+        jittered_timestamps = tsgroup[k].times() + np.random.uniform(-max_jitter,max_jitter,len(tsgroup[k]))
         jittered_tsgroup[k] = nap.Ts(t=np.sort(jittered_timestamps))
 
     if keep_tsupport:

--- a/tests/test_perievent.py
+++ b/tests/test_perievent.py
@@ -23,6 +23,7 @@ def test_align_tsd():
     for i, j in zip(peth.keys(), np.arange(0, 100, 10)):
         np.testing.assert_array_almost_equal(peth[i].index.values, np.arange(-10, 10))
 
+
 def test_compute_perievent_with_tsd():
     tsd = nap.Tsd(t=np.arange(100), d=np.arange(100))
     tref = nap.Ts(t=np.arange(10, 100, 10))

--- a/tests/test_randomize.py
+++ b/tests/test_randomize.py
@@ -30,6 +30,32 @@ def test_shift_tsgroup():
         assert len(tsgroup[j]) == len(shift_tsgroup[k])
 
 
+def test_shuffle_intervals_ts():
+    ts = nap.Ts(t=np.arange(0, 100))
+    shuff_ts = nap.randomize.shuffle_ts_intervals(ts)
+
+    assert len(ts) == len(shuff_ts)
+    assert isinstance(shuff_ts,nap.Ts)
+    assert ts.time_support.values == pytest.approx(shuff_ts.time_support.values)
+    assert np.diff(ts.times()) == pytest.approx(np.diff(shuff_ts.times()))
+
+
+def test_resample_tsgroup():
+    tsgroup = nap.TsGroup(
+        {0: nap.Ts(t=np.arange(0, 100)), 1: nap.Ts(t=np.arange(0, 200))}
+    )
+    shuff_tsgroup = nap.randomize.shuffle_ts_intervals(tsgroup)
+
+    assert isinstance(shuff_tsgroup,nap.TsGroup)
+    assert len(tsgroup) == len(shuff_tsgroup)
+    assert tsgroup.time_support.values == pytest.approx(shuff_tsgroup.time_support.values)
+
+    for j,k in zip(tsgroup.keys(),shuff_tsgroup.keys()):
+        assert j == k
+        assert len(tsgroup[j]) == len(shuff_tsgroup[k])
+        assert np.diff(tsgroup[j].times()) == pytest.approx(np.diff(shuff_tsgroup[k].times()))
+
+
 def test_jitter_ts():
     ts = nap.Ts(t=np.arange(0, 100))
     jitter_ts = nap.randomize.jitter_timestamps(ts,max_jitter=0.1)

--- a/tests/test_randomize.py
+++ b/tests/test_randomize.py
@@ -1,0 +1,76 @@
+"""Tests of randomize for `pynapple` package."""
+
+import pynapple as nap
+import numpy as np
+import pandas as pd
+import pytest
+
+
+def test_shift_ts():
+    ts = nap.Ts(t=np.arange(0, 100))
+    shift_ts = nap.randomize.shift_timestamps(ts,min_shift=0.1,max_shift=0.2)
+
+    assert isinstance(shift_ts,nap.Ts)
+    assert len(ts) == len(shift_ts)
+    assert (ts.time_support.values == shift_ts.time_support.values).all()
+
+
+def test_shift_tsgroup():
+    tsgroup = nap.TsGroup(
+        {0: nap.Ts(t=np.arange(0, 100)), 1: nap.Ts(t=np.arange(0, 200))}
+    )
+    shift_tsgroup = nap.randomize.shift_timestamps(tsgroup,min_shift=0.1,max_shift=0.2)
+
+    assert isinstance(shift_tsgroup,nap.TsGroup)
+    assert len(tsgroup) == len(shift_tsgroup)
+    assert (tsgroup.time_support.values == shift_tsgroup.time_support.values).all()
+
+    for j,k in zip(tsgroup.keys(),shift_tsgroup.keys()):
+        assert j == k
+        assert len(tsgroup[j]) == len(shift_tsgroup[k])
+
+
+def test_jitter_ts():
+    ts = nap.Ts(t=np.arange(0, 100))
+    jitter_ts = nap.randomize.jitter_timestamps(ts,min_jitter=0.01,max_jitter=0.1)
+
+    assert isinstance(jitter_ts,nap.Ts)
+    assert len(ts) == len(jitter_ts)
+
+
+def test_jitter_tsgroup():
+    tsgroup = nap.TsGroup(
+        {0: nap.Ts(t=np.arange(0, 100)), 1: nap.Ts(t=np.arange(0, 200))}
+    )
+    jitter_tsgroup = nap.randomize.jitter_timestamps(tsgroup,min_jitter=0.01,max_jitter=0.1)
+
+    assert isinstance(jitter_tsgroup,nap.TsGroup)
+    assert len(tsgroup) == len(jitter_tsgroup)
+
+    for j,k in zip(tsgroup.keys(),jitter_tsgroup.keys()):
+        assert j == k
+        assert len(tsgroup[j]) == len(jitter_tsgroup[k])
+
+
+def test_resample_ts():
+    ts = nap.Ts(t=np.arange(0, 100))
+    resampled_ts = nap.randomize.resample_timestamps(ts)
+
+    assert len(ts) == len(resampled_ts)
+    assert isinstance(resampled_ts,nap.Ts)
+    assert (ts.time_support.values == resampled_ts.time_support.values).all()
+
+
+def test_resample_tsgroup():
+    tsgroup = nap.TsGroup(
+        {0: nap.Ts(t=np.arange(0, 100)), 1: nap.Ts(t=np.arange(0, 200))}
+    )
+    resampled_tsgroup = nap.randomize.resample_timestamps(tsgroup)
+
+    assert isinstance(resampled_tsgroup,nap.TsGroup)
+    assert len(tsgroup) == len(resampled_tsgroup)
+    assert (tsgroup.time_support.values == resampled_tsgroup.time_support.values).all()
+
+    for j,k in zip(tsgroup.keys(),resampled_tsgroup.keys()):
+        assert j == k
+        assert len(tsgroup[j]) == len(resampled_tsgroup[k])

--- a/tests/test_randomize.py
+++ b/tests/test_randomize.py
@@ -32,7 +32,7 @@ def test_shift_tsgroup():
 
 def test_jitter_ts():
     ts = nap.Ts(t=np.arange(0, 100))
-    jitter_ts = nap.randomize.jitter_timestamps(ts,min_jitter=0.01,max_jitter=0.1)
+    jitter_ts = nap.randomize.jitter_timestamps(ts,max_jitter=0.1)
 
     assert isinstance(jitter_ts,nap.Ts)
     assert len(ts) == len(jitter_ts)
@@ -42,7 +42,7 @@ def test_jitter_tsgroup():
     tsgroup = nap.TsGroup(
         {0: nap.Ts(t=np.arange(0, 100)), 1: nap.Ts(t=np.arange(0, 200))}
     )
-    jitter_tsgroup = nap.randomize.jitter_timestamps(tsgroup,min_jitter=0.01,max_jitter=0.1)
+    jitter_tsgroup = nap.randomize.jitter_timestamps(tsgroup,max_jitter=0.1)
 
     assert isinstance(jitter_tsgroup,nap.TsGroup)
     assert len(tsgroup) == len(jitter_tsgroup)


### PR DESCRIPTION
Dear Guillaume and Pynapple maintainers,

I implemented some randomization procedures for pynapple ts and tsgroup objects, with the idea that they could be useful to compute null distributions for statistical testing.
I tried to follow the contribution guidelines as closely as possible. 
Here is a description of the new functionalities:

I located the routines in process.randomize.py. Currently, there are three types of randomization implemented:

- `shift_timestamps` shifts all the timestamps in a Ts object by a random amount, wrapping the end to the beginning. If applied to a TsGroup, all Ts in the group are independently shifted
- `jitter_timestamps` jitters all the timestamps in a Ts (or TsGroup) of a different random amount, uniformly sampled betw. -max_jitter and max_jitter. By default, the number of timestamps is preserved, and the timesupport can change, but the reverse can be enforced with keep_tsupport=True
- `resample_timestamps` re-draws the same number of timestamps in the time_support of the object.

The functions are implemented to handle a Ts or TsGroup objects, with an interface function exposed to the user that handles exceptions and then calls the relevant strategy depending on the input type.
Tests are currently covering mostly output consistency. I'll be happy to implement further tests if you think more coverage is needed.

I have in mind to implement randomization procedures for time series and time series frames as well. Before proceeding, I'll wait for your feedback. In particular:

- Is a submodule of nap.process the best place to fit these functionalities?
- How is best to handle the different data types? Would it be preferable to have an explicitly different function for each core data type (so split the ts and tsgroup functions, for example?)
- Is it better to have the randomize.py file only contain the functions exposed to the user, not to overcrowd the documentation? 

Thanks for reviewing my PR. I hope these functionalities can be useful.